### PR TITLE
Send record callback

### DIFF
--- a/src/android/com/emj365/plugins/AudioRecorderAPI.java
+++ b/src/android/com/emj365/plugins/AudioRecorderAPI.java
@@ -93,6 +93,10 @@ public class AudioRecorderAPI extends CordovaPlugin {
       Log.i(TAG, "Start recording");
       audioRecorder.startRecording();
       isRecording = true;
+      
+      PluginResult pluginResult = new PluginResult("recording");
+      pluginResult.setKeepCallback(true);
+      recordCallbackContext.sendPluginResult(pluginResult);
 
       recordingThread = new Thread(new Runnable() {
 

--- a/src/android/com/emj365/plugins/AudioRecorderAPI.java
+++ b/src/android/com/emj365/plugins/AudioRecorderAPI.java
@@ -2,6 +2,7 @@ package com.emj365.plugins;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -94,7 +95,7 @@ public class AudioRecorderAPI extends CordovaPlugin {
       audioRecorder.startRecording();
       isRecording = true;
       
-      PluginResult pluginResult = new PluginResult("recording");
+      PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, "recording");
       pluginResult.setKeepCallback(true);
       recordCallbackContext.sendPluginResult(pluginResult);
 

--- a/src/ios/AudioRecorderAPI.m
+++ b/src/ios/AudioRecorderAPI.m
@@ -104,7 +104,10 @@
             NSLog(@"recordForDuration failed");
             return;
         }
-        
+
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"recording"];
+        [pluginResult setKeepCallbackAsBool:YES];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:_command.callbackId];
     }];
 }
 


### PR DESCRIPTION
Added CDVPluginResult on iOS and PluginResult on Android, to warn and activate the recording callback.